### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/org2gist.el
+++ b/org2gist.el
@@ -34,6 +34,7 @@
 
 (require 'gist)
 (require 's)
+(require 'org)
 
 (defun org2gist-subtree-dwim (&optional public)
   "Post or update current org subtree as a gist.
@@ -57,7 +58,7 @@ doesn't toggle the public/private status when editing gists."
              (export-buffer (org-org-export-as-org nil t nil t))
              gist)
         (if (null gist-id)
-            (flet ((gist-ask-for-description-maybe () ((lambda () title))))
+            (cl-letf (((symbol-function 'gist-ask-for-description-maybe) (lambda () title)))
               (rename-buffer filename)
               (gist-region (point-min) (point-max) (= public '1))
               (switch-to-buffer content-buffer)


### PR DESCRIPTION
- load org for using its functions
- Use cl-letf instead of deprecated flet
  - https://www.gnu.org/software/emacs/manual/html_node/cl/Obsolete-Macros.html

```
org2gist.el:60:21: Warning: ‘(gist-ask-for-description-maybe nil ((lambda nil
    title)))’ is a malformed function

In end of data:
org2gist.el:64:16: Warning: the function ‘org-set-property’ is not known to be
    defined.
org2gist.el:60:14: Warning: the function ‘flet’ is not known to be defined.
org2gist.el:57:30: Warning: the function ‘org-org-export-as-org’ is not known
    to be defined.
org2gist.el:54:22: Warning: the function ‘org-get-heading’ is not known to be
    defined.
org2gist.el:53:42: Warning: the function ‘org-find-property’ is not known to
    be defined.
org2gist.el:52:24: Warning: the function ‘org-entry-get-with-inheritance’ is
    not known to be defined.
```